### PR TITLE
Search project recursively for all packages.config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Ted NuGet (Testing External Dependencies in NuGet) performs open sources checks 
 
 ## Installation
 
-Run it as a Python3 script, and direct the stderr to a CSV file.
+Run it as a Python3 script.
+
+Usage: py ted.py [options] <path>
+For help use "-h" flag.
 
 ## Authors
 


### PR DESCRIPTION
For a project with multiple packages.config files, you can now pass it a directory to recursively search for all files rather than running it one at a time for each file. I also updated the README to go into this in detail, and added a help flag (-h).